### PR TITLE
Update site content to align with GitHub profile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ function App() {
           <div className="flex flex-col md:flex-row items-center justify-between mb-8">
             <div className="flex-1 text-center md:text-left mb-6 md:mb-0">
               <h1 className="text-4xl font-bold text-gray-900 mb-4">Grimmer Kang</h1>
-              <p className="text-xl text-gray-600 mb-2">Tech Lead / Engineering Manager</p>
-              <p className="text-base text-gray-500 mb-8">Passionate about building impactful solutions for people</p>
+              <p className="text-xl text-gray-600 mb-2">Tech Lead at <a href="https://fireflies.ai" className="text-blue-600 hover:text-blue-800">Fireflies.ai</a></p>
+              <p className="text-base text-gray-500 mb-8">Building agentic AI systems and LLM architecture for meeting intelligence at scale</p>
             </div>
             <div className="flex-shrink-0 md:ml-8">
               <img src="assets/profile.png" alt="Grimmer Kang"
@@ -19,12 +19,14 @@ function App() {
             </div>
           </div>
           <p className="text-gray-600 max-w-2xl mx-auto md:mx-0 leading-relaxed">
-            Technology leader with physics background, progressing from mobile and full-stack development to
-            AI systems and scalable architectures. Currently leading distributed AI engineering teams at
-            Fireflies.ai. Previously contributed to CARTA, an international astronomy software project at Academia Sinica,
-            collaborating with US National Radio Astronomy Observatory and global partners. Extensive experience in IoT and streaming technologies. Proven track record in
-            building high-performance engineering teams and driving innovation through critical thinking and
-            agile methodologies.
+            15+ years in software engineering, with a physics background (BS + MS). I've worked across AI, medical imaging,
+            astronomy (<a href="https://cartavis.org/" className="text-blue-600 hover:text-blue-800">CARTA</a>, an international C++/JS open-source project at Academia Sinica),
+            IoT, and streaming — primarily in TypeScript, Python, and C/C++.
+            Beyond code, I've built and led mobile and full-stack engineering teams and introduced Agile practices across organizations.
+          </p>
+          <p className="text-gray-600 max-w-2xl mx-auto md:mx-0 leading-relaxed mt-3">
+            <span className="font-semibold text-gray-700">Currently into:</span> LLM agent architecture, RAG systems, context engineering, MCP tooling
+            · Contributor to the <a href="https://github.com/modelcontextprotocol/typescript-sdk" className="text-blue-600 hover:text-blue-800">MCP TypeScript SDK</a>
           </p>
 
 
@@ -70,16 +72,17 @@ function App() {
             </div>
             <div className="p-6 flex flex-col flex-grow justify-between">
               <p className="text-gray-600">
-                Creator of developer tools including VS Code, Chrome extensions, macOS utilities, and
-                an open-source pet healthcare tracking app (previously published on iOS/Android).
-                Author of TypeScript libraries for task queues and numerical computing.
-                Implemented AlphaGo Zero algorithm for tic-tac-toe in TypeScript,
-                demonstrating advanced AI concepts in browser environments.
+                Creator of <a href="https://github.com/grimmerk/codev" className="text-blue-600 hover:text-blue-800 font-medium">CodeV</a> — a macOS app for VS Code/Cursor project switching, Claude Code session management, and AI assistant.
+                Also built a <a href="https://marketplace.visualstudio.com/items?itemName=grimmer.vscode-back-forward-button" className="text-blue-600 hover:text-blue-800">VS Code extension</a> (78,000+ installs),
+                Chrome extensions, TypeScript libraries (<a href="https://www.npmjs.com/package/d4c-queue" className="text-blue-600 hover:text-blue-800">d4c-queue</a> 15K+, <a href="https://www.npmjs.com/package/@d4c/numjs" className="text-blue-600 hover:text-blue-800">@d4c/numjs</a> 20K+ downloads),
+                and a <a href="https://chrome.google.com/webstore/detail/dicom-image-viewer/ehppmcooahfnlfhhcflpkcjmonkoindc" className="text-blue-600 hover:text-blue-800">Medical DICOM Viewer</a> (3,000+ users).
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">TypeScript</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Python</span>
+                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Electron</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">VS Code</span>
+                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Claude AI</span>
               </div>
             </div>
           </div>
@@ -100,16 +103,15 @@ function App() {
             </div>
             <div className="p-6 flex flex-col flex-grow justify-between">
               <p className="text-gray-600">
-                Speaker at PyCon APAC, COSCUP 2021, and FOSSASIA Summit 2025, sharing expertise on Python in browsers for
-                medical imaging applications and TypeScript patterns for concurrent processing, and open source developer 
-                productivity tools. Focused on practical implementations and real-world applications.
+                Speaker at FOSSASIA Summit 2025 (Bangkok), PyCon APAC 2021 (Thailand), PyConTW 2021, and COSCUP 2021.
+                Topics include open-source developer productivity tools, Python in browsers for medical imaging (Pyodide/WebAssembly),
+                and TypeScript patterns for concurrent processing.
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
+                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">FOSSASIA 2025</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">PyCon APAC</span>
+                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">PyConTW</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">COSCUP</span>
-                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">FOSSASIA</span>
-                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Medical Imaging</span>
-                <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Electron</span>
               </div>
             </div>
           </div>
@@ -133,15 +135,60 @@ function App() {
             </div>
             <div className="p-6 flex flex-col flex-grow justify-between">
               <p className="text-gray-600">
-                Led development efforts for CARTA (Cube Analysis and Rendering Tool for Astronomy) at Academia Sinica,
-                an open-source project collaborating with international teams to revitalize its development.
-                Improved core performance and resolved critical issues through close collaboration with astronomers across Taiwan, US, and Canada.
+                Led development of <a href="https://cartavis.org/" className="text-blue-600 hover:text-blue-800">CARTA</a> (Cube Analysis and Rendering Tool for Astronomy) at Academia Sinica,
+                an international C++/JS open-source project collaborating with US (NRAO), Canada, and South Africa teams.
+                Built a full-stack + algorithm team, designed the live collaborative share-screen architecture,
+                and resolved critical issues through close collaboration with astronomers.
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">C++</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">JavaScript</span>
                 <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">Python</span>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Talks Section */}
+      <div className="max-w-6xl mx-auto pt-2 pb-8 px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-gray-900 mb-8">Talks</h2>
+        <div className="bg-white rounded-lg shadow divide-y">
+          <div className="p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <h3 className="font-semibold text-gray-900">FOSSASIA Summit 2025 <span className="text-gray-500 font-normal">— Bangkok</span></h3>
+              <p className="text-gray-600 text-sm mt-1">CodeV: Streamlining Developer Workflow with an Open Source VS Code Launcher</p>
+            </div>
+            <a href="https://slides.com/grimmer/fossasia-2025-switchv-streamlining-developer-workflow-with-an-open-source-vs-code-launcher" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 text-sm whitespace-nowrap">slide</a>
+          </div>
+          <div className="p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <h3 className="font-semibold text-gray-900">PyCon APAC 2021 <span className="text-gray-500 font-normal">— Thailand</span></h3>
+              <p className="text-gray-600 text-sm mt-1">Use Pyodide to run Python in browsers — rendering medical DICOM files</p>
+            </div>
+            <div className="flex gap-3 text-sm">
+              <a href="https://slides.com/grimmer/pyconapac_pyodide_dicom_viewer" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">slide</a>
+              <a href="https://youtu.be/kd4C6KNbHT4" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">video</a>
+            </div>
+          </div>
+          <div className="p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <h3 className="font-semibold text-gray-900">PyConTW 2021 <span className="text-gray-500 font-normal">— Taiwan</span></h3>
+              <p className="text-gray-600 text-sm mt-1">Use Pyodide to run Python in browsers — rendering medical DICOM files</p>
+            </div>
+            <div className="flex gap-3 text-sm">
+              <a href="https://slides.com/grimmer/intro_pyodide_medical_dicom_viewer/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">slide</a>
+              <a href="https://www.youtube.com/watch?v=Wk6sePJb26o" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">video</a>
+            </div>
+          </div>
+          <div className="p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <h3 className="font-semibold text-gray-900">COSCUP 2021 <span className="text-gray-500 font-normal">— Taiwan</span></h3>
+              <p className="text-gray-600 text-sm mt-1">Synchronization & concurrency in JavaScript — introducing d4c-queue</p>
+            </div>
+            <div className="flex gap-3 text-sm">
+              <a href="https://slides.com/grimmer/intro_js_ts_task_queuelib_d4c/fullscreen" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">slide</a>
+              <a href="https://www.youtube.com/watch?v=_wxSAEts35w" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">video</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Hero section**: Updated to match GitHub profile — Fireflies.ai link, "Currently into" LLM/RAG/MCP line, CARTA described as international C++/JS open-source project
- **Developer Tools card**: Highlights CodeV first, updated metrics (78K VS Code installs, 15K d4c-queue, 20K numjs, 3K DICOM users)
- **Technical Speaking card**: FOSSASIA 2025 listed first, added PyConTW 2021
- **CARTA card**: Added international collaboration details (NRAO, Canada, South Africa)
- **New Talks section**: Conference talks with slide/video links between Featured Work and Patent

## Still TODO
- [ ] Add CodeV screenshot as a new Featured Work card (waiting for new version screenshot with Claude Code sessions)
- [ ] Consider updating the "Developer Tools" card image (currently shows VS Code source code)

_🤖 On behalf of @grimmerk — generated with Claude Code_
